### PR TITLE
Mejora del comportamiento de añadir al carrito y mejora del alineado de información de tarjetas de productos

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -290,6 +290,7 @@ button {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     gap: 2rem;
+    align-items: stretch;
 }
 
 .product__card {
@@ -298,6 +299,9 @@ button {
     overflow: hidden;
     box-shadow: 0 2px 8px rgba(0,0,0,.1);
     transition: .3s;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
 }
 
 .product__card:hover {
@@ -312,6 +316,14 @@ button {
 
 .product__content {
     padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+}
+
+.product__description {
+    margin-bottom: var(--mb-2);
+    flex-grow: 1;
 }
 
 .product__title {
@@ -1174,6 +1186,7 @@ button {
     .product__buttons {
     display: flex;
     gap: 0.5rem;
+        margin-top: auto;
     }
     
     .product__buttons .button--secondary {

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
     <nav class="nav container">
       <a href="/thecocktailstore" class="nav__logo">
         <i class="fas fa-laptop"></i>
-        The Cocktail Store
+        The Cocktail Store!
       </a>
 
       <!-- <div class="nav__menu">

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
     <nav class="nav container">
       <a href="/thecocktailstore" class="nav__logo">
         <i class="fas fa-laptop"></i>
-        The Cocktail Store!
+        The Cocktail Store
       </a>
 
       <!-- <div class="nav__menu">

--- a/js/ui/productsUI.js
+++ b/js/ui/productsUI.js
@@ -76,8 +76,8 @@ export class ProductsUI {
       button.textContent = "¡Añadido!";
       button.classList.add("added");
       setTimeout(() => {
-        button.textContent = "Añadir al Carrito";
         button.classList.remove("added");
+        button.innerHTML = `<i class="fas fa-cart-plus"></i>`;
       }, 1500);
     }
   }


### PR DESCRIPTION
Hola Edu

He hecho dos cambios pequeños:

1. Antes, cuando el usuario añadía un producto haciendo click en el botón de Add to cart de las tarjetas en el home, el estado del botón luego de algunos segundos no funcionaba correctamente. Antes mostraba un texto y no el icono original. Ahora sí se muestra el icono original del carrito.

2. He mejorado la forma de alineación de los botones de ver detalles y añadir al carrito de las tarjedas de productos en home. Antes, si las descripciones tenían tamaños distintos, los botones y el precio se ubicaban más arriba o abajo en la tarjeta respecto al resto de productos. Ahora la alineación es correcta independientemente del largo de la descripción.